### PR TITLE
Fix build issues with cover image and build process

### DIFF
--- a/book.yaml
+++ b/book.yaml
@@ -41,7 +41,7 @@ pdf:
 
 # EPUB settings
 epub:
-  cover_image: "art/cover.png"  # Path to cover image
+  cover_image: "book/images/cover.png"  # Path to cover image
   css: "templates/epub/style.css"  # Custom CSS (optional)
   toc_depth: 3  # Table of contents depth
 

--- a/tools/scripts/generate-epub.sh
+++ b/tools/scripts/generate-epub.sh
@@ -76,7 +76,10 @@ fi
 LANG_COVER_IMAGE=""
 if [ -f "book/$LANGUAGE/images/cover.png" ]; then
   LANG_COVER_IMAGE="book/$LANGUAGE/images/cover.png"
-  echo "✅ Found language-specific cover image at $LANG_COVER_IMAGE"
+  echo "✅ Found language-specific cover image (PNG) at $LANG_COVER_IMAGE"
+elif [ -f "book/$LANGUAGE/images/cover.jpg" ]; then
+  LANG_COVER_IMAGE="book/$LANGUAGE/images/cover.jpg"
+  echo "✅ Found language-specific cover image (JPG) at $LANG_COVER_IMAGE"
 elif [ -f "build/$LANGUAGE/images/cover.png" ]; then
   LANG_COVER_IMAGE="build/$LANGUAGE/images/cover.png"
   echo "✅ Found language-specific cover image at $LANG_COVER_IMAGE"
@@ -86,9 +89,14 @@ elif [ -n "$EPUB_COVER_IMAGE" ]; then
 fi
 
 # If no cover image is found after all checks, use the one in the build directory
-if [ -z "$LANG_COVER_IMAGE" ] && [ -f "build/images/cover.png" ]; then
-  LANG_COVER_IMAGE="build/images/cover.png"
-  echo "Using cover image found in build directory: $LANG_COVER_IMAGE"
+if [ -z "$LANG_COVER_IMAGE" ]; then
+  if [ -f "build/images/cover.png" ]; then
+    LANG_COVER_IMAGE="build/images/cover.png"
+    echo "Using cover image found in build directory: $LANG_COVER_IMAGE"
+  elif [ -f "build/images/cover.jpg" ]; then
+    LANG_COVER_IMAGE="build/images/cover.jpg"
+    echo "Using JPG cover image found in build directory: $LANG_COVER_IMAGE"
+  fi
 fi
 
 # Build the pandoc command base

--- a/tools/scripts/setup.sh
+++ b/tools/scripts/setup.sh
@@ -66,6 +66,18 @@ if [ -z "$COVER_IMAGE" ]; then
     COVER_IMAGE="book/images/cover.png"
     cp "$COVER_IMAGE" build/images/cover.png
     
+  elif [ -f "book/images/cover.jpg" ]; then
+    echo "✅ Found cover image at book/images/cover.jpg"
+    COVER_IMAGE="book/images/cover.jpg"
+    # Convert jpg to png if possible, otherwise just copy it
+    if command -v convert &> /dev/null; then
+      convert "$COVER_IMAGE" build/images/cover.png
+      echo "  Converted JPG to PNG for compatibility"
+    else
+      cp "$COVER_IMAGE" build/images/cover.jpg
+      ln -sf build/images/cover.jpg build/images/cover.png 2>/dev/null || true
+    fi
+    
   else
     # Look in language-specific directories
     for lang in "${LANGUAGES[@]}"; do
@@ -73,6 +85,18 @@ if [ -z "$COVER_IMAGE" ]; then
         echo "✅ Found cover image at book/$lang/images/cover.png"
         COVER_IMAGE="book/$lang/images/cover.png"
         cp "$COVER_IMAGE" build/images/cover.png
+        break
+      elif [ -f "book/$lang/images/cover.jpg" ]; then
+        echo "✅ Found cover image at book/$lang/images/cover.jpg"
+        COVER_IMAGE="book/$lang/images/cover.jpg"
+        # Convert jpg to png if possible, otherwise just copy it
+        if command -v convert &> /dev/null; then
+          convert "$COVER_IMAGE" build/images/cover.png
+          echo "  Converted JPG to PNG for compatibility"
+        else
+          cp "$COVER_IMAGE" build/images/cover.jpg
+          ln -sf build/images/cover.jpg build/images/cover.png 2>/dev/null || true
+        fi
         break
       fi
     done


### PR DESCRIPTION
This PR fixes several issues with the book building process, particularly focusing on the cover image handling:

## Changes:
1. Updated `book.yaml` to correctly reference the cover image at `book/images/cover.png` instead of the non-existent `art/cover.png`
2. Enhanced `setup.sh` to better detect and handle both JPG and PNG cover images:
   - Added support for JPG cover images with optional conversion to PNG if `imagemagick` is available
   - Improved debugging and logging for cover image detection
3. Improved `generate-epub.sh` to support both JPG and PNG cover images:
   - Expanded search paths for cover images
   - Better error handling and logging

This should resolve the issue with not seeing builds in the release, as the workflow should now be able to properly find and use the cover images that actually exist in the repository.

Fixes issue with reference to cover image mentioned by @iksnae.