### PR TITLE
Fix PDF generation issues in LaTeX template

### DIFF
--- a/book.yaml
+++ b/book.yaml
@@ -41,7 +41,7 @@ pdf:
 
 # EPUB settings
 epub:
-  cover_image: "art/cover.png"  # Path to cover image
+  cover_image: "book/images/cover.png"  # Path to cover image
   css: "templates/epub/style.css"  # Custom CSS (optional)
   toc_depth: 3  # Table of contents depth
 

--- a/book/en/chapter-01/00-introduction.md
+++ b/book/en/chapter-01/00-introduction.md
@@ -45,9 +45,15 @@ Numbered lists:
 
 ### Images
 
-To add an image:
+To add an image, use this syntax:
 
-![Example image description](images/example-image.jpg)
+```markdown
+![Image description](images/filename.jpg)
+```
+
+For example, you can reference an image from the book's main images directory:
+
+![Book cover](../../images/cover.jpg)
 
 ### Tables
 

--- a/templates/pdf/default.latex
+++ b/templates/pdf/default.latex
@@ -16,6 +16,11 @@
 \usepackage{float}
 \usepackage{titlesec}
 \usepackage{fancyhdr}
+\usepackage{enumitem}
+
+% Define tightlist command - needed for Pandoc's markdown conversion
+\providecommand{\tightlist}{%
+  \setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}
 
 % Configure fonts
 \defaultfontfeatures{Ligatures=TeX,Scale=MatchLowercase}

--- a/tools/scripts/generate-epub.sh
+++ b/tools/scripts/generate-epub.sh
@@ -76,7 +76,10 @@ fi
 LANG_COVER_IMAGE=""
 if [ -f "book/$LANGUAGE/images/cover.png" ]; then
   LANG_COVER_IMAGE="book/$LANGUAGE/images/cover.png"
-  echo "✅ Found language-specific cover image at $LANG_COVER_IMAGE"
+  echo "✅ Found language-specific cover image (PNG) at $LANG_COVER_IMAGE"
+elif [ -f "book/$LANGUAGE/images/cover.jpg" ]; then
+  LANG_COVER_IMAGE="book/$LANGUAGE/images/cover.jpg"
+  echo "✅ Found language-specific cover image (JPG) at $LANG_COVER_IMAGE"
 elif [ -f "build/$LANGUAGE/images/cover.png" ]; then
   LANG_COVER_IMAGE="build/$LANGUAGE/images/cover.png"
   echo "✅ Found language-specific cover image at $LANG_COVER_IMAGE"
@@ -86,9 +89,14 @@ elif [ -n "$EPUB_COVER_IMAGE" ]; then
 fi
 
 # If no cover image is found after all checks, use the one in the build directory
-if [ -z "$LANG_COVER_IMAGE" ] && [ -f "build/images/cover.png" ]; then
-  LANG_COVER_IMAGE="build/images/cover.png"
-  echo "Using cover image found in build directory: $LANG_COVER_IMAGE"
+if [ -z "$LANG_COVER_IMAGE" ]; then
+  if [ -f "build/images/cover.png" ]; then
+    LANG_COVER_IMAGE="build/images/cover.png"
+    echo "Using cover image found in build directory: $LANG_COVER_IMAGE"
+  elif [ -f "build/images/cover.jpg" ]; then
+    LANG_COVER_IMAGE="build/images/cover.jpg"
+    echo "Using JPG cover image found in build directory: $LANG_COVER_IMAGE"
+  fi
 fi
 
 # Build the pandoc command base

--- a/tools/scripts/setup.sh
+++ b/tools/scripts/setup.sh
@@ -66,6 +66,18 @@ if [ -z "$COVER_IMAGE" ]; then
     COVER_IMAGE="book/images/cover.png"
     cp "$COVER_IMAGE" build/images/cover.png
     
+  elif [ -f "book/images/cover.jpg" ]; then
+    echo "✅ Found cover image at book/images/cover.jpg"
+    COVER_IMAGE="book/images/cover.jpg"
+    # Convert jpg to png if possible, otherwise just copy it
+    if command -v convert &> /dev/null; then
+      convert "$COVER_IMAGE" build/images/cover.png
+      echo "  Converted JPG to PNG for compatibility"
+    else
+      cp "$COVER_IMAGE" build/images/cover.jpg
+      ln -sf build/images/cover.jpg build/images/cover.png 2>/dev/null || true
+    fi
+    
   else
     # Look in language-specific directories
     for lang in "${LANGUAGES[@]}"; do
@@ -73,6 +85,18 @@ if [ -z "$COVER_IMAGE" ]; then
         echo "✅ Found cover image at book/$lang/images/cover.png"
         COVER_IMAGE="book/$lang/images/cover.png"
         cp "$COVER_IMAGE" build/images/cover.png
+        break
+      elif [ -f "book/$lang/images/cover.jpg" ]; then
+        echo "✅ Found cover image at book/$lang/images/cover.jpg"
+        COVER_IMAGE="book/$lang/images/cover.jpg"
+        # Convert jpg to png if possible, otherwise just copy it
+        if command -v convert &> /dev/null; then
+          convert "$COVER_IMAGE" build/images/cover.png
+          echo "  Converted JPG to PNG for compatibility"
+        else
+          cp "$COVER_IMAGE" build/images/cover.jpg
+          ln -sf build/images/cover.jpg build/images/cover.png 2>/dev/null || true
+        fi
         break
       fi
     done


### PR DESCRIPTION
This PR fixes issues with the PDF generation that were preventing the books from being properly built:

## Changes:

1. **Added missing `\tightlist` command in LaTeX template**:
   - The PDF generation was failing with an "Undefined control sequence \tightlist" error
   - Added the proper definition to the LaTeX template
   - Also added the `enumitem` package for better list handling

2. **Fixed broken image reference in the introduction chapter**:
   - Changed the non-existent image reference to point to the existing cover image
   - Updated the example to show correct image path syntax
   - Replaced the example with actual working code that references the existing cover

These changes should allow the PDF generation to complete successfully, which should then allow the full book to be properly built and released.

Note: This builds on top of the previous PR #11 which fixed the cover image paths in configuration.